### PR TITLE
Fix page name hard limit check

### DIFF
--- a/lib/func.php
+++ b/lib/func.php
@@ -156,7 +156,7 @@ function is_pagename_bytes_within_soft_limit($page)
 
 function is_pagename_bytes_within_hard_limit($page)
 {
-	return strlen($page) <= PKWK_PAGENAME_BYTES_SOFT_LIMIT;
+        return strlen($page) <= PKWK_PAGENAME_BYTES_HARD_LIMIT;
 }
 
 function page_exists_in_history($page)


### PR DESCRIPTION
## Summary
- fix is_pagename_bytes_within_hard_limit to use the right constant
- run PHP syntax check

## Testing
- `php -l lib/func.php`
- `find . -name '*.php' -not -path './plugin/vendor/*' -not -path './lib/mbstring.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6873ae504e2483258533d6e7f318b59f