### PR TITLE
Fix Markdown preview

### DIFF
--- a/plugin/edit.inc.php
+++ b/plugin/edit.inc.php
@@ -96,10 +96,14 @@ function plugin_edit_preview($msg)
 	$msg = preg_replace(PLUGIN_EDIT_FREEZE_REGEX, '', $msg);
 
 // Pukiwiki-Markdown
-	$write_notemd = isset($vars['notemd']) && $vars['notemd'] != '';
-	if ( ! preg_match('/(^|\n)\#notemd\n/',$msg) && $write_notemd) {
-		$msg = add_notemd($msg);
-	}
+       $write_notemd = isset($vars['notemd']) && $vars['notemd'] != '';
+       if ($write_notemd) {
+               if (!preg_match('/(^|\n)\#notemd\n/', $msg)) {
+                       $msg = add_notemd($msg);
+               }
+       } else {
+               $msg = remove_notemd($msg);
+       }
 
 	$postdata = $msg;
 
@@ -116,53 +120,11 @@ function plugin_edit_preview($msg)
 		$body .= '<strong>' . $_msg_preview_delete . '</strong>';
 	$body .= '<br />' . "\n";
 
-	if ($postdata) {
-		$postdata = make_str_rules($postdata);
-		$postdata = explode("\n", $postdata);
-		if (! preg_grep('/^\#notemd/', $postdata) ){
-			$postdata = drop_submit(convert_html($postdata));
-		} else {
-			// Markdown記法
-			foreach ( $postdata as &$line ) {
-				$matches = array();
-				
-				$line = preg_replace('/(\#author\(.*\)|\#notemd|\#freeze)/', '', $line); // #author,#notemd,#freezeはMarkdown Parserに渡さない
-				if ( preg_match('/^\\!([a-zA-Z0-9_]+)(\\(([^\\)\\n]*)?\\))?/', $line, $matches) ) {
-					$plugin = $matches[1];
-					if ( exist_plugin_convert($plugin) ) {
-						$name = 'plugin_' . $matches[1] . '_convert';
-						$params = array();
-						if ( isset($matches[3]) ) {
-							$params = explode(',', $matches[3]);
-						}
-						$line = call_user_func_array($name, $params);
-					} else {
-						$line = "plugin ${plugin} failed.";
-					}
-				} else if (preg_match('/^\!(\[.*\])(\((https?\:\/\/[\-_\.\!\~\*\'\(\)a-zA-Z0-9\;\/\?\:\@\&\=\+\$\,\%\#]+\.)?(jpe?g|png|gif|webp)\))/u', $line, $matchimg)) {
-					// Markdown記法の画像の場合はmake_linkに渡さない
-				} else {
-					// $line = preg_replace('/\[(.*?)\]\((https?\:\/\/[\-_\.\!\~\*\'\(\)a-zA-Z0-9\;\/\?\:\@\&\=\+\$\,\%\#]+)( )?(\".*\")?\)/', "[[$1>$2]]", $line); // Markdown式リンクをPukiwiki式リンクに変換
-					$line = preg_replace('/\[\[(.+)[\:\>](https?\:\/\/[\-_\.\!\~\*\'\(\)a-zA-Z0-9\;\/\?\:\@\&\=\+\$\,\%\#]+)\]\]/', "[$1]($2)", $line); // Pukiwiki式リンクをMarkdown式リンクに変換
-					$line = preg_replace('/\[\#[a-zA-Z0-9]{8}\]$/', "", $line); // Pukiwiki式アンカーを非表示に
-					$line = make_link($line);
-					// ファイル読み込んだ場合に改行コードが末尾に付いていることがあるので削除
-					// 空白は削除しちゃだめなのでrtrim()は使ってはいけない
-				}
-			$line = str_replace(array("\r\n","\n","\r"), "", $line);
-			}
-			unset($line);
-		
-			$postdata = implode("\n", $postdata);
-		
-			$parsedown = new \Parsedown(); //Parsedown→ParsedownExtraに変更しても良い
-			$postdata = drop_submit($parsedown
-			->setBreaksEnabled(true) // enables automatic line breaks
-			->text($postdata));
-
-		}
-		$body .= '<div id="preview">' . $postdata . '</div>' . "\n";
-	}
+        if ($postdata) {
+                $postdata = make_str_rules($postdata);
+                $postdata = drop_submit(convert_html($postdata));
+                $body .= '<div id="preview">' . $postdata . '</div>' . "\n";
+        }
 	$body .= edit_form($page, $msg, $vars['digest'], FALSE);
 
 	return array('msg'=>$_title_preview, 'body'=>$body);
@@ -328,10 +290,14 @@ function plugin_edit_write()
 	}
 
 	// Pukiwiki-Markdown
-	$write_notemd = isset($vars['notemd']) && $vars['notemd'] != '';
-	if ( ! preg_match('/(^|\n)\#notemd\n/',$postdata) && $write_notemd) {
-		$postdata = add_notemd($postdata);
-	}
+       $write_notemd = isset($vars['notemd']) && $vars['notemd'] != '';
+       if ($write_notemd) {
+               if (!preg_match('/(^|\n)\#notemd\n/', $postdata)) {
+                       $postdata = add_notemd($postdata);
+               }
+       } else {
+               $postdata = remove_notemd($postdata);
+       }
 
 	page_write($page, $postdata, $notimeupdate != 0 && $notimestamp);
 	pkwk_headers_sent();


### PR DESCRIPTION
## Summary
- preview Markdown using the standard parser
- remove or insert `#notemd` based on checkbox selection

## Testing
- `php -l plugin/edit.inc.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68781e403f7c83259397d4467b6ff67f