### PR TITLE
league/commonmark専用化とPukiWiki脚注の併用対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,63 +45,32 @@ PukiWikiではどうしても書き方が馴染めないという人が少なく
 
 ## 使用しているMarkdownパーサー
 
-PukiWiki Markdown対応版では、**3種類のMarkdownパーサーから選択可能**です（`pukiwiki.ini.php`の`$markdown_parser`で設定）。
+このバージョンは **league/commonmark 2.x 専用**です。
 
-### league/commonmark 2.x（推奨・デフォルト）
+### league/commonmark 2.x
 - **GitHub Flavored Markdown（GFM）完全対応**
 - 打ち消し線（`~~text~~`）、タスクリスト（`- [ ]`）、オートリンク、テーブルなど
 - **Pandocスタイルのインライン脚注**（`^[text]`）と通常の脚注（`[^1]`）の両方に対応
+- **PukiWikiスタイルのインライン脚注**（`((text))`）も併用可能
 - 継続的にメンテナンスされている最新のMarkdownパーサー
 - **ライセンス**: BSD-3-Clause
 
-### ParsedownExtra 0.8.1 + インライン脚注拡張
-- Parsedownの拡張機能に加え、独自拡張でインライン脚注に対応
-- テーブル、脚注、定義リストなどの拡張記法に対応
-- **Pandocスタイルのインライン脚注**（`^[text]`）をサポート（独自実装）
-- 軽量で高速（league/commonmarkより高速）
-- **ライセンス**: MIT
+### システム要件
+- **PHP 7.4以上**（必須）
+- **Composer経由でleague/commonmarkをインストール済み**（vendorディレクトリに含まれています）
 
-### Parsedown 1.7.4（基本版）
-- 高速で軽量なMarkdownパーサー
-- 基本的なMarkdown記法のみ対応
-- 拡張機能やインライン脚注は使用不可
-- **ライセンス**: MIT
-
-**推奨**: GitHub Flavored Markdownの全機能とインライン脚注を使いたい場合は **league/commonmark**（デフォルト）を選択してください。
+**Note**: Parsedown系パーサーは使用できません。PukiWiki本体はPHP 5.6以降で動作しますが、このMarkdown対応版はPHP 7.4以上が必要です。
 
 ---
 
 ## 設定項目（pukiwiki.ini.php）
 
-### `$markdown_parser = 'commonmark';`
-使用するMarkdownパーサーの選択（**新機能**）
-- `'commonmark'`: **league/commonmark 2.x**（推奨・デフォルト）
-  - GitHub Flavored Markdown完全対応
-  - 打ち消し線、タスクリスト、オートリンク、テーブル、脚注など全機能
-  - Pandocスタイルのインライン脚注（`^[text]`）に対応
-- `'parsedown_extra'`: **ParsedownExtra + インライン脚注拡張**
-  - テーブル、脚注、定義リストなどの拡張記法
-  - Pandocスタイルのインライン脚注（`^[text]`）に対応（独自実装）
-  - 軽量で高速
-- `'parsedown'`: **Parsedown 基本版**
-  - 基本的なMarkdown記法のみ（軽量・高速）
-  - 拡張機能は使用不可
-
-**Note**: `commonmark`と`parsedown_extra`の両方でインライン脚注が使用できます。
-
 ### `$use_markdown_cache = 1;`
-Markdownキャッシュ機能（**新機能**）
+Markdownキャッシュ機能
 - `1`: 有効（推奨） - Markdown変換結果をキャッシュして高速化
 - `0`: 無効 - 毎回変換（開発・デバッグ時のみ）
 
 **Note**: キャッシュを有効にすると、Markdown変換が初回の1/10～1/20の時間で完了します（例: 20ms → 1ms）。ページ内容が変更された場合、自動的にキャッシュは更新されます。
-
-### `$markdown_safemode = 1;`
-Markdownのセーフモード設定
-- `1`: 有効（推奨） - XSS攻撃などを防ぐ
-- `0`: 無効 - 生HTMLの埋め込みが可能（セキュリティリスクあり）
-
-**Note**: `commonmark`パーサーでは、この設定に関わらず常にセーフモードで動作します。
 
 ### `$default_notemd = 1;`
 新規ページのデフォルトモード設定
@@ -117,13 +86,6 @@ EasyMDEエディタの使用設定（SimpleMDEの後継）
 
 **Note**: EasyMDE v2.20.0がローカルに配置されています（`skin/js/easymde.min.{css,js}`）。SimpleMDEは2017年から開発停止のため、EasyMDEに移行しました。
 
-### `$use_parsedown_extra = 1;`（非推奨 - 後方互換性のため維持）
-ParsedownExtraの使用設定（拡張Markdown記法）
-- `1`: 有効 - テーブルや脚注などの拡張記法が使用可能
-- `0`: 無効 - 基本的なMarkdown記法のみ
-
-**Note**: この設定は後方互換性のため残されています。新しい`$markdown_parser`設定を使用してください。
-
 ### `$markdown_debug_mode = 0;`
 Markdownデバッグモード
 - `1`: 有効 - HTMLコメントとして詳細なデバッグ情報を出力（パーサー名、キャッシュヒット/ミスなど）
@@ -133,10 +95,9 @@ Markdownデバッグモード
 
 ## 拡張Markdown記法
 
-PukiWikiでは、選択したパーサー（`commonmark`または`parsedown_extra`）に応じて、様々な拡張Markdown記法が使用できます。
+このバージョンは **league/commonmark (GitHub Flavored Markdown)** を使用しています。以下の拡張記法が使用できます。
 
 ### テーブル（GitHub Flavored Markdown形式）
-**対応**: `commonmark`, `parsedown_extra`
 
 ```markdown
 | ヘッダー1 | ヘッダー2 |
@@ -144,10 +105,9 @@ PukiWikiでは、選択したパーサー（`commonmark`または`parsedown_extr
 | セル1    | セル2    |
 ```
 
-### 脚注
+### 脚注（3種類の記法をサポート）
 
-#### 参照スタイル脚注（Reference-style footnotes）
-**対応**: `commonmark`, `parsedown_extra`
+#### 1. 参照スタイル脚注（Reference-style footnotes）
 
 ```markdown
 本文中に脚注[^1]を挿入できます。
@@ -155,24 +115,29 @@ PukiWikiでは、選択したパーサー（`commonmark`または`parsedown_extr
 [^1]: これが脚注の内容です
 ```
 
-#### インライン脚注（Inline footnotes）- Pandocスタイル
-**対応**: `commonmark`, `parsedown_extra`
+#### 2. インライン脚注（Inline footnotes）- Pandocスタイル
 
 ```markdown
 本文中にインライン脚注^[これがインライン脚注です]を挿入できます。
 ```
 
-**Note**: インライン脚注は、脚注の内容が短い場合に便利です。参照スタイル脚注とインライン脚注は同時に使用できます。両方のパーサーでサポートされています。
+#### 3. インライン脚注（PukiWikiスタイル）
+
+```markdown
+本文中にインライン脚注((これがPukiWiki脚注です))を挿入できます。
+```
+
+**重要**: Markdown記法モード（`#notemd`指定時）でも、**PukiWikiスタイルの脚注 `((text))` が使えます**。Pandoc脚注 `^[text]` と併用可能です。PukiWikiユーザーが慣れ親しんだ記法をそのまま使えます。
+
+**Note**: 脚注の内容が短い場合はインライン脚注が便利です。参照スタイル脚注とインライン脚注は同時に使用できます。
 
 ### 打ち消し線（Strikethrough）
-**対応**: `commonmark`のみ（GitHub Flavored Markdown）
 
 ```markdown
 ~~打ち消し線~~
 ```
 
 ### タスクリスト（Task Lists）
-**対応**: `commonmark`のみ（GitHub Flavored Markdown）
 
 ```markdown
 - [x] 完了したタスク
@@ -180,23 +145,13 @@ PukiWikiでは、選択したパーサー（`commonmark`または`parsedown_extr
 ```
 
 ### オートリンク
-**対応**: `commonmark`のみ（GitHub Flavored Markdown）
 
 ```markdown
 https://example.com （自動的にリンクになります）
 user@example.com （メールアドレスも自動的にリンクになります）
 ```
 
-### 定義リスト
-**対応**: `parsedown_extra`のみ
-
-```markdown
-用語
-: 定義
-```
-
 ### Fenced Code Blocks
-**対応**: `commonmark`, `parsedown_extra`
 
 ````markdown
 ```言語名
@@ -204,9 +159,10 @@ user@example.com （メールアドレスも自動的にリンクになります
 ```
 ````
 
-### その他の拡張機能
-**ParsedownExtra**: 省略語、特殊属性など
-**league/commonmark**: テーブル内のパイプエスケープ、HTML属性の追加など
+### その他のGitHub Flavored Markdown機能
+- テーブル内のパイプエスケープ（`\|`）
+- HTMLブロックの埋め込み（安全なもののみ）
+- オートリンクの拡張（www.example.comも自動リンク化）
 
 ---
 

--- a/UPDATES.md
+++ b/UPDATES.md
@@ -1,9 +1,79 @@
 # pukiwiki154_md アップデート履歴
 
-## 2025-11-28: Markdownパーサー選択機能とキャッシュ機能の追加
+## 2025-11-28: league/commonmark専用化とPukiWiki脚注の併用対応
+
+### 概要
+Markdown処理を **league/commonmark 2.x専用** に変更しました。これにより、Markdown記法モード（`#notemd`）でも**PukiWikiスタイルの脚注 `((text))` が使える**ようになりました。Pandoc脚注 `^[text]` と併用可能です。
+
+### 主な変更内容
+
+#### 1. league/commonmark専用化
+- Parsedown系パーサー（parsedown, parsedown_extra）のサポートを終了
+- コードを大幅に簡略化（100行以上削減）
+- 保守性とパフォーマンスが向上
+
+#### 2. PukiWiki脚注の併用対応
+**重要な新機能**: Markdown記法モードでも **`((text))` のPukiWiki脚注が使える**ようになりました。
+
+- `make_link()` で生成されたHTML（PukiWiki脚注など）を保持
+- league/commonmarkの `'html_input' => 'allow'` 設定により実現
+- Pandoc脚注 `^[text]` とPukiWiki脚注 `((text))` の併用が可能
+- PukiWikiユーザーが慣れ親しんだ記法をそのまま使用可能
+
+#### 3. システム要件の明確化
+- **PHP 7.4以上が必須**（league/commonmark 2.xの要件）
+- Composer経由でleague/commonmarkがインストール済み（vendorディレクトリに含まれる）
+- PukiWiki本体はPHP 5.6以降だが、このMarkdown対応版はPHP 7.4以上が必要
+
+### 変更ファイル
+
+#### lib/convert_html.php
+- **大幅な簡略化**（約100行削減）
+- `init_markdown_parser()` を league/commonmark専用に書き換え
+- `convert_html()` 関数の簡略化（パーサーAPI差異チェックを削除）
+- グローバル変数を削減（`$markdown_parser`, `$markdown_safemode`を削除）
+
+#### pukiwiki.ini.php
+- `$markdown_parser` 設定を削除（commonmark固定）
+- `$use_parsedown_extra` 設定を削除
+- PukiWiki脚注 `((text))` が併用可能であることを明記
+- PHP 7.4以上の要件を明記
+
+#### README.md
+- パーサーセクションを全面改訂（commonmark専用化）
+- **PukiWiki脚注 `((text))` の説明を追加**（重要）
+- システム要件（PHP 7.4以上）を追加
+- 設定項目を簡略化
+
+### 脚注記法の比較
+
+Markdown記法モード（`#notemd`）では、以下の3種類の脚注記法が使用できます：
+
+```markdown
+# 1. 参照スタイル脚注（Markdown標準）
+本文中に脚注[^1]を挿入できます。
+[^1]: これが脚注の内容です
+
+# 2. Pandocスタイルインライン脚注
+本文中にインライン脚注^[これがPandoc脚注です]を挿入できます。
+
+# 3. PukiWikiスタイルインライン脚注
+本文中にインライン脚注((これがPukiWiki脚注です))を挿入できます。
+```
+
+**メリット**: PukiWikiユーザーは慣れ親しんだ `((text))` 記法をMarkdownモードでもそのまま使用できます。
+
+### コミット
+- 機能追加: league/commonmark専用化とPukiWiki脚注の併用対応
+
+---
+
+## 2025-11-28: Markdownパーサー選択機能とキャッシュ機能の追加（※後にleague/commonmark専用化）
 
 ### 概要
 3種類のMarkdownパーサーから選択可能になり、GitHub Flavored Markdown完全対応の **league/commonmark 2.x** をデフォルトとして追加しました。また、Markdown変換結果のキャッシュ機能を実装し、パフォーマンスが大幅に向上しました。
+
+**Note**: このバージョンは後にleague/commonmark専用化されました（上記参照）。
 
 ### 主な変更内容
 

--- a/pukiwiki.ini.php
+++ b/pukiwiki.ini.php
@@ -670,16 +670,19 @@ $markdown_safemode = 1;
 // この設定は新規ページ作成時のみ適用されます。既存ページの編集には影響しません。
 $default_notemd = 1;
 
-// Markdownパーサーの選択
-// 'commonmark'      - GitHub Flavored Markdown完全対応（推奨・デフォルト）
-//                     打ち消し線、タスクリスト、オートリンク、テーブル、脚注など全機能
-// 'parsedown_extra' - 拡張記法サポート（テーブル、脚注、定義リスト）
-//                     インライン脚注（独自拡張）をサポート
-// 'parsedown'       - 基本的なMarkdown記法のみ（軽量・高速）
-$markdown_parser = 'commonmark';
+// Markdownパーサー: league/commonmark 2.x（固定）
+// GitHub Flavored Markdown完全対応
+// - 打ち消し線（~~text~~）、タスクリスト（- [ ]）、オートリンク
+// - テーブル、Fenced Code Blocks
+// - 参照スタイル脚注（[^1]）、Pandocスタイルインライン脚注（^[text]）
+// - PukiWikiスタイルインライン脚注（((text))）も併用可能
+//
+// 要件: PHP 7.4以上、composer経由でleague/commonmarkがインストール済み
+// Note: このバージョンはleague/commonmark専用です。Parsedown系は使用できません。
 
 // Markdownキャッシュ機能
 // 1:Enable - Markdown変換結果をキャッシュして高速化（推奨）
+//            初回変換後、10～20倍高速化（20ms → 1ms）
 // 0:Disable - 毎回変換（開発・デバッグ時のみ）
 $use_markdown_cache = 1;
 
@@ -688,13 +691,6 @@ $use_markdown_cache = 1;
 // 0:Disable - 標準のテキストエリアを使用
 // Note: 変数名は後方互換性のため$use_simplemdeのまま維持しています
 $use_simplemde = 1;
-
-// 後方互換性のための設定（非推奨 - 上記$markdown_parserを使用してください）
-// ParsedownExtra（拡張Markdown記法）
-// 1:Enable - テーブル、脚注、定義リストなどの拡張記法が使用可能
-// 0:Disable - 基本的なMarkdown記法のみ使用
-// Note: $markdown_parserが設定されている場合、この設定は無視されます
-$use_parsedown_extra = 1;
 
 // Markdownデバッグモード
 // 1:Enable - HTMLコメントとして詳細なデバッグ情報を出力（開発時のみ使用）


### PR DESCRIPTION
## 概要
Markdown処理を **league/commonmark 2.x専用** に変更し、Markdown記法モード（`#notemd`）でも**PukiWikiスタイルの脚注 `((text))` が使える**ようになりました。

## 主な変更内容

### 1. league/commonmark専用化
- Parsedown系パーサー（parsedown, parsedown_extra）のサポートを終了
- コードを大幅に簡略化（100行以上削減）
- 保守性とパフォーマンスが向上

### 2. PukiWiki脚注の併用対応
**重要な新機能**: Markdown記法モードでも **`((text))` のPukiWiki脚注が使える**ようになりました。

- `make_link()` で生成されたHTML（PukiWiki脚注など）を保持
- league/commonmarkの `'html_input' => 'allow'` 設定により実現
- Pandoc脚注 `^[text]` とPukiWiki脚注 `((text))` の併用が可能
- PukiWikiユーザーが慣れ親しんだ記法をそのまま使用可能

### 3. システム要件の明確化
- **PHP 7.4以上が必須**（league/commonmark 2.xの要件）
- Composer経由でleague/commonmarkがインストール済み（vendorディレクトリに含まれる）

## 脚注記法の比較

Markdown記法モード（`#notemd`）では、以下の3種類の脚注記法が使用できます：

```markdown
# 1. 参照スタイル脚注（Markdown標準）
本文中に脚注[^1]を挿入できます。
[^1]: これが脚注の内容です

# 2. Pandocスタイルインライン脚注
本文中にインライン脚注^[これがPandoc脚注です]を挿入できます。

# 3. PukiWikiスタイルインライン脚注
本文中にインライン脚注((これがPukiWiki脚注です))を挿入できます。
